### PR TITLE
New functionality for Find & Replace Text, per conversation on Airtable community forums

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,11 @@ async function getStringsToFindAndReplace() {
   // enter the string you want to find...
   let stringToFind = await input.textAsync('Enter the string to find');
   // ...and the string you want to replace it with
-  let stringToReplace = await input.textAsync('Enter the string to replace it with');
+  let stringToReplace = "";
+  let replaceOrRemove = await input.buttonsAsync('Replace with a new string, or remove string?', ["Replace", "Remove"]);
+  if (replaceOrRemove == "Replace") {
+    stringToReplace = await input.textAsync('Enter the string to replace it with');
+  }
   // define a new regex based on the sting to find
   // this configuration replaces all instances of the string to find and is case sensitive
   let myRegex = new RegExp(stringToFind,"g");

--- a/script.js
+++ b/script.js
@@ -9,6 +9,8 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 //
 // AUTHOR: Jonathan Bowen (www.dragondrop.uk)
+// Additional changes by Kuovonne Vorderbruggen
+//
 // SCRIPT: Script for Airtable script block to find and replace text
 // DISCLAIMER:
 // - Test the script first on a copy of your base
@@ -18,60 +20,107 @@
 // - Use at your own risk!
 
 
-// user chooses the table...
-let table = await input.tableAsync('Pick a table');
-// ...and a field
-let field = await input.fieldAsync("Pick a field", table);
-// Shows the field name and field type
-output.text(`Field "${field.name}" has type "${field.type}".`);
+await airtableFindAndReplace();
 
-// The script only works against text-type fields
-if(field.type == 'singleLineText' || field.type == 'multilineText' || field.type == 'richText') {
-    // enter the string you want to find...
-    let stringToFind = await input.textAsync('Enter the string to find');
-    // ...and the string you want to replace it with
-    let stringToReplace = await input.textAsync('Enter the string to replace it with');
-    // define a new regex based on the sting to find
-    // this configuration replaces all instances of the string to find and is case sensitive
-    let myRegex = new RegExp(stringToFind,"g");
-    // get the records from the table
-    let query = await table.selectRecordsAsync();
-    let countOfRecords = 0;
-    output.text("The following records will be changed:")
-    // get the records which contain the string to find and output the before and after version
-    // note that records are not changed at this point, we're just showing what will be changed if you go ahead
-    for (let record of query.records) {
-        if (record.getCellValue(field.name).includes(stringToFind)) {
-            let newText = record.getCellValue(field.name).replace(myRegex, stringToReplace);
-            output.text(`(Record: ${record.name}) ${record.getCellValue(field.name)} => ${newText}`);
-            output.text("============================");
-            countOfRecords = countOfRecords += 1;
-        }
+async function airtableFindAndReplace() {
+  let scriptDescription = "This script performs a **find and replace** for a single column/field of a table ";
+  scriptDescription += "using [regular expressions](https://en.wikipedia.org/wiki/Regular_expression).";
+  output.markdown(scriptDescription);
+  let {table, field} = await pickTableAndField();
+  if (field == null) {
+    // can't do find and replace if there is no text field
+    return;
+  }
+  let {stringToFind, stringToReplace, myRegex} = await getStringsToFindAndReplace();
+  await performFindAndReplace(table, field, stringToFind, stringToReplace, myRegex);
+}
+
+
+async function pickTableAndField() {
+  // user chooses the table...
+  let table = await input.tableAsync('Pick a table');
+  // ...and a field
+  // The script only works against text-type fields
+  let allowedFields = table.fields.filter((field) =>{
+    switch(field.type) {
+      case "singleLineText":
+      case "multilineText":
+      case "richText":
+        return true;
+      default:
+        return false;
     }
-    // if nothing matches the string to find, then finish
-    if (countOfRecords == 0) {
-        output.text("Sorry - can't find any records to update - please try again!")
-    } else if (countOfRecords > 0) {
-        // otherwise check with the user if they want to proceed with the find and replace
-        let proceedOrCancel = await input.buttonsAsync('Would you like to proceed or cancel?', ['Proceed', 'Cancel']);
-        if (proceedOrCancel === 'Proceed') {
-            output.text('Proceeding...');
-            for (let record of query.records) {
-                if (record.getCellValue(field.name).includes(stringToFind)) {
-                    let newText = record.getCellValue(field.name).replace(myRegex, stringToReplace);
-                    // update the records
-                    let update = table.updateRecordAsync(record, {
-                        [field.name]: newText
-                    })
-                    output.text(`Record: ${record.name} updated`);
-                }
-            }
-            output.text("The find and replace action has finished")
-        } else {
-            output.text("The find and replace action was cancelled");
-        }
-    }
-} else {
-    // if field type is not a text type field then let the user know
-    output.text(`Sorry - can't do find & replace on a ${field.type} field`);
+  });
+  let field;
+  if (allowedFields.length > 1) {
+    // have user select button for text field
+    let allowedFieldNames = allowedFields.map(field => field.name);
+    let fieldName = await input.buttonsAsync('Pick a field', allowedFieldNames);
+    field = table.getField(fieldName);
+  } else if (allowedFields.length == 1) {
+    // only one text field to use
+    field = allowedFields[0];
+  } else {
+    field = null;
+  }
+  // Shows the field name
+  if (field) {
+    output.text(`Doing find and replace on field "${field.name}" in table "${table.name}".`);
+  } else {
+    output.text(`Sorry - no text fields in table "${table.name}".`);
+  }
+  return {table, field};
+}
+
+
+async function getStringsToFindAndReplace() {
+  // enter the string you want to find...
+  let stringToFind = await input.textAsync('Enter the string to find');
+  // ...and the string you want to replace it with
+  let stringToReplace = await input.textAsync('Enter the string to replace it with');
+  // define a new regex based on the sting to find
+  // this configuration replaces all instances of the string to find and is case sensitive
+  let myRegex = new RegExp(stringToFind,"g");
+  return {stringToFind, stringToReplace, myRegex}
+}
+
+
+async function performFindAndReplace(table, field, stringToFind, stringToReplace, myRegex) {
+  // get the records from the table
+  let query = await table.selectRecordsAsync();
+  let countOfRecords = 0;
+  output.text("The following records will be changed:")
+  // get the records which contain the string to find and output the before and after version
+  // note that records are not changed at this point, we're just showing what will be changed if you go ahead
+  for (let record of query.records) {
+      if (record.getCellValue(field.name) && record.getCellValue(field.name).includes(stringToFind)) {
+          let newText = record.getCellValue(field.name).replace(myRegex, stringToReplace);
+          output.text(`(Record: ${record.name}) ${record.getCellValue(field.name)} => ${newText}`);
+          output.text("============================");
+          countOfRecords = countOfRecords += 1;
+      }
+  }
+  // if nothing matches the string to find, then finish
+  if (countOfRecords == 0) {
+      output.text("Sorry - can't find any records to update - please try again!")
+  } else if (countOfRecords > 0) {
+      // otherwise check with the user if they want to proceed with the find and replace
+      let proceedOrCancel = await input.buttonsAsync('Would you like to proceed or cancel?', ['Proceed', 'Cancel']);
+      if (proceedOrCancel === 'Proceed') {
+          output.text('Proceeding...');
+          for (let record of query.records) {
+              if (record.getCellValue(field.name) && record.getCellValue(field.name).includes(stringToFind)) {
+                  let newText = record.getCellValue(field.name).replace(myRegex, stringToReplace);
+                  // update the records
+                  let update = await table.updateRecordAsync(record, {
+                      [field.name]: newText
+                  })
+                  output.text(`Record: ${record.name} updated`);
+              }
+          }
+          output.text("The find and replace action has finished")
+      } else {
+          output.text("The find and replace action was cancelled");
+      }
+  }
 }


### PR DESCRIPTION
I added some functionality to the script, based on my [comments](https://community.airtable.com/t/script-block-find-replace-text/28658/2) in the Airtable community forum.
- tell user that the script uses regular expressions
- limit field selection to only allowable text fields
- give users the option to remove text instead of replacing text

In order to add this functionality, I also split the script into several functions, which makes it look like there are more lines changed than really were.
